### PR TITLE
Main app window - redesign

### DIFF
--- a/DesktopApp/View/MainWindow.xaml
+++ b/DesktopApp/View/MainWindow.xaml
@@ -10,11 +10,11 @@
         Height="700" Width="1000"
         AllowsTransparency="True" Background="Transparent"
         WindowStyle="None"
-        ResizeMode="CanResize"
+        ResizeMode="CanResizeWithGrip"
         IsManipulationEnabled="True">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="35"/>
             <RowDefinition Height="15*"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
@@ -22,8 +22,7 @@
         <Border CornerRadius="10" Grid.RowSpan="3">
             <Border.Background>
                 <LinearGradientBrush StartPoint="1,0" EndPoint="1,1">
-                    <GradientStop Color="White" Offset="0"/>
-                    <GradientStop Color="#1e1e1e" Offset="0.05"/>
+                    <GradientStop Color="#1e1e1e" Offset="0.1"/>
                     <GradientStop Color="#1e1e10" Offset="0.5"/>
                 </LinearGradientBrush>
             </Border.Background>
@@ -35,21 +34,30 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="5*"/>
-                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="125"/>
             </Grid.ColumnDefinitions>
 
-            <Rectangle Grid.ColumnSpan="3" Opacity="0" Fill="AliceBlue" Grid.Column="0" StrokeThickness="10" Margin="0,0,0,0"/>
+            <Border CornerRadius="10,10,0,0" Grid.ColumnSpan="3">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="1,0" EndPoint="1,2">
+                        <GradientStop Color="WhiteSmoke" Offset="0.1"/>
+                        <GradientStop Color="Transparent" Offset="0.5"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+            </Border>
 
-            <Image Source="/View/Resources/Images/Logo.png" Stretch="Uniform" VerticalAlignment="Top" Height="100" Grid.Column="0" Margin="0,0,0,-42"/>
+            <Rectangle Grid.ColumnSpan="3" Opacity="0" Fill="Transparent" Grid.Column="0" StrokeThickness="10"/>
+
+            <Image Source="/View/Resources/Images/Logo.png" Stretch="Uniform" VerticalAlignment="Top" Height="100" Grid.Column="0"/>
 
             <TextBlock Text="Hephaestus" Grid.Column="1" FontSize="20" FontFamily="Impact" HorizontalAlignment="Left" Margin="5" Foreground="White"/>
 
             <StackPanel Grid.Column="2" Margin="10" Orientation="Horizontal">
-                <Button Background="Transparent" Margin="50,0,0,10" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
+                <Button Background="Transparent" Margin="50,0,0,0" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
                     <Image Source="/View/Resources/Images/MinimizeIcon.png" Stretch="Fill"/>
                 </Button>
 
-                <Button Background="Transparent" Margin="20,0,0,10" BorderThickness="0" Command="{Binding CloseButtonCommand}">
+                <Button Background="Transparent" Margin="20,0,0,0" BorderThickness="0" Command="{Binding CloseButtonCommand}">
                     <Image Source="/View/Resources/Images/CloseIcon.png" Stretch="Fill"/>
                 </Button>
             </StackPanel>

--- a/DesktopApp/View/MainWindow.xaml
+++ b/DesktopApp/View/MainWindow.xaml
@@ -15,14 +15,15 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="7*"/>
+            <RowDefinition Height="15*"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
         <Border CornerRadius="10" Grid.RowSpan="3">
             <Border.Background>
                 <LinearGradientBrush StartPoint="1,0" EndPoint="1,1">
-                    <GradientStop Color="#1e1e1e" Offset="0"/>
+                    <GradientStop Color="White" Offset="0"/>
+                    <GradientStop Color="#1e1e1e" Offset="0.05"/>
                     <GradientStop Color="#1e1e10" Offset="0.5"/>
                 </LinearGradientBrush>
             </Border.Background>
@@ -37,18 +38,18 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <Image Source="/View/Resources/Images/Logo.png"
-                   Stretch="None" VerticalAlignment="Top" Height="145"
-                   Grid.Column="0"/>
+            <Rectangle Grid.ColumnSpan="3" Opacity="0" Fill="AliceBlue" Grid.Column="0" StrokeThickness="10" Margin="0,0,0,0"/>
 
-            <TextBlock Text="Hephaestus" Grid.Column="1" FontSize="30" FontFamily="Impact" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="White"/>
+            <Image Source="/View/Resources/Images/Logo.png" Stretch="Uniform" VerticalAlignment="Top" Height="100" Grid.Column="0" Margin="0,0,0,-42"/>
+
+            <TextBlock Text="Hephaestus" Grid.Column="1" FontSize="20" FontFamily="Impact" HorizontalAlignment="Left" Margin="5" Foreground="White"/>
 
             <StackPanel Grid.Column="2" Margin="10" Orientation="Horizontal">
-                <Button Background="Transparent" Margin="20,0,0,40" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
+                <Button Background="Transparent" Margin="50,0,0,10" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
                     <Image Source="/View/Resources/Images/MinimizeIcon.png" Stretch="Fill"/>
                 </Button>
 
-                <Button Background="Transparent" Margin="20,0,0,40" BorderThickness="0" Command="{Binding CloseButtonCommand}">
+                <Button Background="Transparent" Margin="20,0,0,10" BorderThickness="0" Command="{Binding CloseButtonCommand}">
                     <Image Source="/View/Resources/Images/CloseIcon.png" Stretch="Fill"/>
                 </Button>
             </StackPanel>

--- a/DesktopApp/View/MainWindow.xaml
+++ b/DesktopApp/View/MainWindow.xaml
@@ -18,11 +18,11 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <Border CornerRadius="50" Grid.RowSpan="3">
+        <Border CornerRadius="10" Grid.RowSpan="3">
             <Border.Background>
-                <LinearGradientBrush>
-                    <GradientStop Color="Gray" Offset="0.3"/>
-                    <GradientStop Color="LightSlateGray" Offset="1"/>
+                <LinearGradientBrush StartPoint="1,0" EndPoint="1,1">
+                    <GradientStop Color="CadetBlue" Offset="0"/>
+                    <GradientStop Color="LightSteelBlue" Offset="0.3"/>
                 </LinearGradientBrush>
             </Border.Background>
         </Border>
@@ -37,13 +37,13 @@
             </Grid.ColumnDefinitions>
 
             <Image Source="/View/Resources/Images/Logo.png"
-               Stretch="UniformToFill" VerticalAlignment="Center" Height="180"
-               Grid.Column="0"/>
+                   Stretch="UniformToFill" VerticalAlignment="Center" Height="145"
+                   Grid.Column="0"/>
 
             <TextBlock Text="Hephaestus" Grid.Column="1" FontSize="40" FontFamily="Impact" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="White"/>
 
             <StackPanel Grid.Column="2" Margin="10" Orientation="Horizontal">
-                <Button Background="Transparent" Margin="50,0,0,100" BorderThickness="0" Click="MinimizeIconClicked">
+                <Button Background="Transparent" Margin="50,0,0,100" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
                     <Image Source="/View/Resources/Images/MinimizeIcon.png"/>
                 </Button>
 
@@ -55,5 +55,7 @@
 
 
         <!-- Main app content -->
+        <Grid Grid.Row="1" Margin="20">
+        </Grid>
     </Grid>
 </Window>

--- a/DesktopApp/View/MainWindow.xaml
+++ b/DesktopApp/View/MainWindow.xaml
@@ -30,7 +30,7 @@
 
 
         <!-- Header: contains main icon, logo and window state actions -->
-        <Grid Grid.Row="0">
+        <Grid Grid.Row="0" MouseDown="HeaderMouseDownEventHandler">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="5*"/>

--- a/DesktopApp/View/MainWindow.xaml
+++ b/DesktopApp/View/MainWindow.xaml
@@ -10,10 +10,11 @@
         Height="700" Width="1000"
         AllowsTransparency="True" Background="Transparent"
         WindowStyle="None"
-        ResizeMode="NoResize">
+        ResizeMode="CanResize"
+        IsManipulationEnabled="True">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="2*"/>
+            <RowDefinition Height="*"/>
             <RowDefinition Height="7*"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
@@ -21,8 +22,8 @@
         <Border CornerRadius="10" Grid.RowSpan="3">
             <Border.Background>
                 <LinearGradientBrush StartPoint="1,0" EndPoint="1,1">
-                    <GradientStop Color="CadetBlue" Offset="0"/>
-                    <GradientStop Color="LightSteelBlue" Offset="0.3"/>
+                    <GradientStop Color="#1e1e1e" Offset="0"/>
+                    <GradientStop Color="#1e1e10" Offset="0.5"/>
                 </LinearGradientBrush>
             </Border.Background>
         </Border>
@@ -31,24 +32,24 @@
         <!-- Header: contains main icon, logo and window state actions -->
         <Grid Grid.Row="0">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="5*"/>
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
             <Image Source="/View/Resources/Images/Logo.png"
-                   Stretch="UniformToFill" VerticalAlignment="Center" Height="145"
+                   Stretch="None" VerticalAlignment="Top" Height="145"
                    Grid.Column="0"/>
 
-            <TextBlock Text="Hephaestus" Grid.Column="1" FontSize="40" FontFamily="Impact" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="White"/>
+            <TextBlock Text="Hephaestus" Grid.Column="1" FontSize="30" FontFamily="Impact" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="White"/>
 
             <StackPanel Grid.Column="2" Margin="10" Orientation="Horizontal">
-                <Button Background="Transparent" Margin="50,0,0,100" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
-                    <Image Source="/View/Resources/Images/MinimizeIcon.png"/>
+                <Button Background="Transparent" Margin="20,0,0,40" BorderThickness="0" Command="{Binding MinimizeButtonCommand}">
+                    <Image Source="/View/Resources/Images/MinimizeIcon.png" Stretch="Fill"/>
                 </Button>
 
-                <Button Background="Transparent" Margin="20,0,0,100" BorderThickness="0" Command="{Binding CloseButtonCommand}">
-                    <Image Source="/View/Resources/Images/CloseIcon.png"/>
+                <Button Background="Transparent" Margin="20,0,0,40" BorderThickness="0" Command="{Binding CloseButtonCommand}">
+                    <Image Source="/View/Resources/Images/CloseIcon.png" Stretch="Fill"/>
                 </Button>
             </StackPanel>
         </Grid>

--- a/DesktopApp/View/MainWindow.xaml.cs
+++ b/DesktopApp/View/MainWindow.xaml.cs
@@ -31,5 +31,11 @@ namespace DesktopApp
 
         public Command CloseButtonCommand
         { get; set; }
+
+        private void HeaderMouseDownEventHandler(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if( e.ChangedButton == System.Windows.Input.MouseButton.Left )
+                this.DragMove();
+        }
     }
 }

--- a/DesktopApp/View/MainWindow.xaml.cs
+++ b/DesktopApp/View/MainWindow.xaml.cs
@@ -14,20 +14,20 @@ namespace DesktopApp
             InitializeComponent();
             DataContext = this;
 
+            MinimizeButtonCommand = new Command( () => WindowState = WindowState.Minimized );
+            CloseButtonCommand = new Command( () => Close() );
+
             DesktopApp.View.Screens.LoginWindow loginWindow = new View.Screens.LoginWindow();
             loginWindow.ShowDialog();
-        }
-
-
-        private void MinimizeIconClicked( object sender, RoutedEventArgs e )
-        {
-            WindowState = WindowState.Minimized;
         }
 
 
         public ViewModels.LoginViewModel LoginScreen
         { get; set; }
 
+
+        public Command MinimizeButtonCommand
+        { get; set; }
 
         public Command CloseButtonCommand
         { get; set; }


### PR DESCRIPTION
This pull request redesigns the main application window layout and look.

The changes are:
* Theme and colors changed to dark
gray/black gradient for main window content background and white/transparent for header.
* Header behavior improved
Application can now be moved by dragging with grip of the header
Header is now constant and always visible no matter of application window resize
* Minimize button added
* Logo and title improved
